### PR TITLE
Secure user responses and invitation tokens

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -111,7 +111,9 @@ export class AuthService {
   }
 
   private generateInviteToken() {
-    return randomBytes(32).toString('base64url');
+    // 48 cryptographically secure random bytes yields a 64-character URL-safe token
+    // that is sufficiently resistant to brute-force guessing.
+    return randomBytes(48).toString('base64url');
   }
 
   private generateToken(user: { id: string; clinicId: string; role: UserRole; email: string; fullName: string }) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,6 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
+export type SafeUser = {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  clinicId: string;
+  isActive: boolean;
+  invitedAt: Date | null;
+  invitationId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 const userSafeSelect = {
   id: true,
   email: true,
@@ -18,14 +31,14 @@ const userSafeSelect = {
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
 
-  getUserById(id: string) {
+  getUserById(id: string): Promise<SafeUser | null> {
     return this.prisma.user.findUnique({
       where: { id },
       select: userSafeSelect,
     });
   }
 
-  listClinicUsers(clinicId: string) {
+  listClinicUsers(clinicId: string): Promise<SafeUser[]> {
     return this.prisma.user.findMany({
       where: { clinicId },
       select: userSafeSelect,


### PR DESCRIPTION
## Summary
- return only non-sensitive user fields from the users service and annotate the return types to avoid leaking password hashes
- increase the randomness of invitation tokens by using 48 bytes of crypto-secure entropy and documenting the rationale

## Testing
- npm run build (backend)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1684b90c83219e979a3702435e78)